### PR TITLE
change EasyDateTime to `implements DateTime` for complete drop-in compatibility

### DIFF
--- a/lib/src/easy_date_time.dart
+++ b/lib/src/easy_date_time.dart
@@ -64,7 +64,7 @@ part 'easy_date_time_formatting.dart';
 /// {@template easyDateTime}
 /// This class is immutable and can be safely used as a value object.
 /// {@endtemplate}
-class EasyDateTime implements Comparable<EasyDateTime> {
+class EasyDateTime implements DateTime {
   /// The underlying TZDateTime from the timezone package.
   final TZDateTime _tzDateTime;
 
@@ -504,8 +504,9 @@ class EasyDateTime implements Comparable<EasyDateTime> {
   }
 
   /// Returns the [Duration] between this and [other].
-  Duration difference(EasyDateTime other) {
-    return _tzDateTime.difference(other._tzDateTime);
+  @override
+  Duration difference(DateTime other) {
+    return _tzDateTime.difference(other);
   }
 
   // ============================================================
@@ -525,21 +526,20 @@ class EasyDateTime implements Comparable<EasyDateTime> {
   /// final yesterday = now - Duration(days: 1);
   /// ```
   EasyDateTime operator -(Duration duration) => subtract(duration);
-
   /// Returns `true` if this is before [other].
-  bool operator <(EasyDateTime other) =>
+  bool operator <(DateTime other) =>
       microsecondsSinceEpoch < other.microsecondsSinceEpoch;
 
   /// Returns `true` if this is after [other].
-  bool operator >(EasyDateTime other) =>
+  bool operator >(DateTime other) =>
       microsecondsSinceEpoch > other.microsecondsSinceEpoch;
 
   /// Returns `true` if this is before or at the same moment as [other].
-  bool operator <=(EasyDateTime other) =>
+  bool operator <=(DateTime other) =>
       microsecondsSinceEpoch <= other.microsecondsSinceEpoch;
 
   /// Returns `true` if this is after or at the same moment as [other].
-  bool operator >=(EasyDateTime other) =>
+  bool operator >=(DateTime other) =>
       microsecondsSinceEpoch >= other.microsecondsSinceEpoch;
 
   // ============================================================
@@ -547,11 +547,13 @@ class EasyDateTime implements Comparable<EasyDateTime> {
   // ============================================================
 
   /// Returns `true` if this is before [other].
-  bool isBefore(EasyDateTime other) =>
+  @override
+  bool isBefore(DateTime other) =>
       microsecondsSinceEpoch < other.microsecondsSinceEpoch;
 
   /// Returns `true` if this is after [other].
-  bool isAfter(EasyDateTime other) =>
+  @override
+  bool isAfter(DateTime other) =>
       microsecondsSinceEpoch > other.microsecondsSinceEpoch;
 
   /// Returns `true` if this and [other] represent the same moment in time.
@@ -560,11 +562,12 @@ class EasyDateTime implements Comparable<EasyDateTime> {
   /// different timezones.
   ///
   /// This is consistent with [DateTime.isAtSameMomentAs].
-  bool isAtSameMomentAs(EasyDateTime other) =>
+  @override
+  bool isAtSameMomentAs(DateTime other) =>
       microsecondsSinceEpoch == other.microsecondsSinceEpoch;
 
   @override
-  int compareTo(EasyDateTime other) {
+  int compareTo(DateTime other) {
     return microsecondsSinceEpoch.compareTo(other.microsecondsSinceEpoch);
   }
 


### PR DESCRIPTION
@MasterHiei   I have a question about the design decision to not implement DateTime directly.  If you had a reason for this then please feel free to disregard this PR...

   Within my code bases that I have been migrating to EasyDateTime I use DateFormat from the intl library extensively...

For now I have modified all my code to use `.toDateTime()` to convert the `EasyDateTime` to a `DateTime` , as that is what the. `DateFormat` `format()` methods expect...  (well actually return the internal `TZDateTime` as you know)
  
This PR adjust `EasyDateTime` so that it just `implements DateTime` just as the `TZDateTime` class does.

To resolve this and make EasyDateTime a true subtype of DateTime, I have:

1) Changed the class definition to `implements DateTime`.
2) Updated compareTo, isBefore, isAfter, isAtSameMomentAs, and difference to accept DateTime instead of just EasyDateTime.
3) Updated the operators <, >, <=, >= to accept DateTime as well, for better interoperability.

With these changes `EasyDateTime` is a valid `DateTime` and can be passed to any method expecting a `DateTime`.

Note on Equality:
EasyDateTime's operator == implementation checks for absolute time equality (ignoring timezone), whereas DateTime's default implementation checks for both time and timezone equality. I have left operator == unchanged to preserve your existing logic, but be aware of this difference when comparing EasyDateTime with standard DateTime objects.

All test still pass...

I understand you may have had your reasons - i just feel that would be super convenient if we could just pass `EasyDateTime` objects to all existing `DateFormat` or any other class expecting a `DateTime`.
Adding '.toDateTime()' calls was the major change work I needed (and continue to need) to do to convert to `EasyDateTime`.

What do you think about this ?


