### PR TITLE
add caching to EasyDateTimeFormatter and ability to combine patterns/formatters

### DIFF
--- a/lib/src/easy_date_time_formatting.dart
+++ b/lib/src/easy_date_time_formatting.dart
@@ -311,7 +311,7 @@ extension EasyDateTimeFormatting on EasyDateTime {
 /// ```
 class EasyDateTimeFormatter {
   /// Cache all created formatters, as they are immutable.
-  static Map<String, EasyDateTimeFormatter> _availablePatterns = {};
+  static final Map<String, EasyDateTimeFormatter> _availablePatterns = {};
 
   /// The pattern string used by this formatter.
   final String pattern;


### PR DESCRIPTION
This adds caching to `EasyDateTimeFormatter` - as these are immutable and it is quite likely that the same pattern could be being used/created in different places.

It also adds a couple methods for combining formatters or creating a new formatter by adding a pattern to an existing formatter.  (I am think of this for the .addXYZ() type methods of DateFormat from intl)
(I understand that we don't want to re-create intl's DateFormat, but some functionality may be useful)

