### PR TITLE
add isUTC optional named argument to fromMicrosecondsSinceEpoch and fromSecondsSinceEpoch

### DIFF
--- a/lib/src/easy_date_time.dart
+++ b/lib/src/easy_date_time.dart
@@ -256,7 +256,24 @@ class EasyDateTime implements Comparable<EasyDateTime> {
   factory EasyDateTime.fromSecondsSinceEpoch(
     int seconds, {
     Location? location,
+    bool isUtc = false,
   }) {
+    if (isUtc) {
+      if (location != null) {
+        throw ArgumentError.value(
+          location,
+          'location',
+          'Cannot specify location when isUtc is true',
+        );
+      }
+
+      return EasyDateTime._(
+        TZDateTime.fromMillisecondsSinceEpoch(
+          getLocation('UTC'),
+          seconds * 1000,
+        ),
+      );
+    }  
     return EasyDateTime.fromMillisecondsSinceEpoch(
       seconds * 1000,
       location: location,
@@ -269,7 +286,24 @@ class EasyDateTime implements Comparable<EasyDateTime> {
   factory EasyDateTime.fromMicrosecondsSinceEpoch(
     int microseconds, {
     Location? location,
+    bool isUtc = false,
   }) {
+    if (isUtc) {
+      if (location != null) {
+        throw ArgumentError.value(
+          location,
+          'location',
+          'Cannot specify location when isUtc is true',
+        );
+      }
+
+      return EasyDateTime._(
+        TZDateTime.fromMicrosecondsSinceEpoch(
+          getLocation('UTC'),
+          microseconds,
+        ),
+      );
+    }  
     return EasyDateTime._(
       TZDateTime.fromMicrosecondsSinceEpoch(
         location ?? config.effectiveDefaultLocation,


### PR DESCRIPTION
This rounds out the 'drop-in' compatibility for the `DateTime`'s `isUtc` optional argument and adds it to `fromMicrosecondsSinceEpoch` also.   I also added it to `fromSecondsSinceEpoch` (which is unique to EasyDateTime but I thought it made sense from an API consistency/completeness standpoint).